### PR TITLE
Add secret support for terminal commands

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -16,7 +16,13 @@ from .simple import (
     delete_path,
     vm_execute,
 )
-from .tools import execute_terminal, execute_terminal_async, set_vm
+from .tools import (
+    execute_terminal,
+    execute_terminal_async,
+    execute_with_secret,
+    execute_with_secret_async,
+    set_vm,
+)
 from .utils.helpers import limit_chars
 from .vm import LinuxVM
 
@@ -30,6 +36,8 @@ __all__ = [
     "send_to_junior_async",
     "set_team",
     "set_vm",
+    "execute_with_secret",
+    "execute_with_secret_async",
     "LinuxVM",
     "limit_chars",
     "solo_chat",

--- a/agent/utils/secrets.py
+++ b/agent/utils/secrets.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+__all__ = ["get_secret"]
+
+import os
+from getpass import getpass
+
+from .logging import get_logger
+
+_LOG = get_logger(__name__)
+
+
+def get_secret(name: str, prompt: str | None = None) -> str:
+    """Return a secret value from the environment or ask the operator.
+
+    Parameters
+    ----------
+    name:
+        Name of the environment variable to retrieve.
+    prompt:
+        Optional prompt to display when requesting the secret interactively.
+
+    Returns
+    -------
+    str
+        The secret value.
+
+    Notes
+    -----
+    When the value is not available in the environment, the function falls back
+    to :func:`getpass.getpass` so the secret is not echoed back to the console.
+    """
+    value = os.getenv(name)
+    if value:
+        return value
+
+    msg = prompt or f"Enter value for {name}: "
+    try:
+        return getpass(msg)
+    except Exception as exc:  # pragma: no cover - unforeseen errors
+        _LOG.error("Failed to obtain secret %s: %s", name, exc)
+        raise RuntimeError(f"Secret {name} not provided") from exc


### PR DESCRIPTION
## Summary
- add utility to retrieve secrets via env vars or prompt
- extend `LinuxVM.execute` to accept stdin input
- enhance terminal tools with secret execution helpers
- expose new helpers at package level

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c915cd3048321b5b530c65e3603cd