### PR TITLE
Fix terminal tool schema and add user input support

### DIFF
--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+
 
 __all__ = [
     "execute_terminal",
@@ -10,7 +10,7 @@ __all__ = [
 
 import subprocess
 import os
-from typing import Optional, Callable
+from typing import Any, Optional, Callable
 import asyncio
 from functools import partial
 
@@ -41,7 +41,7 @@ def execute_terminal(
     command: str,
     *,
     stdin_data: str | bytes | None = None,
-    input_callback: Optional[Callable[[str], str]] = None,
+    input_callback: Any | None = None,
 ) -> str:
     """
     Execute a shell command in an **unrestricted** Debian terminal.
@@ -99,7 +99,7 @@ async def execute_terminal_async(
     command: str,
     *,
     stdin_data: str | bytes | None = None,
-    input_callback: Optional[Callable[[str], str]] = None,
+    input_callback: Any | None = None,
 ) -> str:
     """Asynchronously execute a shell command."""
     loop = asyncio.get_running_loop()

--- a/run.py
+++ b/run.py
@@ -6,9 +6,18 @@ import agent
 from agent.vm import VMRegistry
 
 async def _main() -> None:
-    document = await agent.upload_document("requirements.txt")
-    async for resp in agent.solo_chat("what is in requirements.txt", user="test_user", session="test_session", think=False): # or agent.team_chat()
-        print("\n>>>", resp)
+    await agent.upload_document("requirements.txt")
+    user = "test_user"
+    session = "test_session"
+    async for resp in agent.solo_chat(
+        "what is in requirements.txt", user=user, session=session, think=False
+    ):  # or agent.team_chat()
+        if resp.startswith("[INPUT REQUIRED]"):
+            prompt = resp.removeprefix("[INPUT REQUIRED]").strip()
+            user_input = input(f"{prompt} ")
+            await agent.send_input(user_input, user=user, session=session)
+        else:
+            print("\n>>>", resp)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- relax `execute_terminal` parameter type so `ollama` schema works
- handle user input prompts in `run.py`
- update Discord bot to notify about input prompts and add `!input` command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684da8332cc88321b88b8025725a06fc