### PR TITLE
Improve Docker fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 `llmOS-Agent` provides an asynchronous chat interface built around Ollama models. It supports running shell commands in an isolated Linux VM and persists conversations in SQLite.
 
-## This repo requires Python >= 3.10 and Docker installed on your system!
+## This repo requires Python >= 3.10. Docker is recommended but optional.
+
+If Docker is not available, shell commands are executed directly on the host
+with reduced isolation. Installing Docker ensures commands run inside a
+dedicated VM for better separation.
 
 ## Features
 

--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -30,7 +30,7 @@ from .schema import Msg, ChatEvent
 from contextlib import suppress
 
 from ..tools import execute_terminal, set_vm
-from ..vm import VMRegistry
+from ..vm import VMRegistry, is_docker_available
 
 from .state import SessionState, get_state
 from .messages import (
@@ -114,8 +114,12 @@ class ChatSession:
         self._think = value
 
     async def __aenter__(self) -> "ChatSession":
-        self._vm = VMRegistry.acquire(self._user.username)
-        set_vm(self._vm)
+        if is_docker_available():
+            self._vm = VMRegistry.acquire(self._user.username)
+            set_vm(self._vm)
+        else:
+            self._vm = None
+            set_vm(None)
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:

--- a/agent/vm/__init__.py
+++ b/agent/vm/__init__.py
@@ -6,6 +6,7 @@ from functools import partial
 from pathlib import Path
 import re
 import io
+import shutil
 
 from threading import Lock
 
@@ -16,6 +17,22 @@ import pexpect
 from ..utils.logging import get_logger
 
 _LOG = get_logger(__name__)
+
+
+def is_docker_available() -> bool:
+    """Return ``True`` if the ``docker`` executable and daemon are available."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception:
+        return False
+    return True
 
 
 def _sanitize(name: str) -> str:


### PR DESCRIPTION
## Summary
- document optional Docker usage and local fallback
- detect missing Docker and avoid VM startup
- gracefully fall back to host command execution

## Testing
- `pip install -q -r requirements.txt`
- `python run.py` *(fails: Failed to connect to Ollama)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2f303bc832197998ca5731fa0e3