### PR TITLE
Refactor VM shell to use PTY

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ peewee
 discord.py
 colorama
 python-dotenv
-pexpect


### PR DESCRIPTION
## Summary
- replace `pexpect` with `pty` and `subprocess` in VM execution
- drop `pexpect` from requirements

## Testing
- `python -m compileall -q agent`
- `pip install -r requirements.txt`
- `python run.py` *(fails: Failed to connect to Ollama)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8d81be88321a8c967789608ea2b