### PR TITLE
Return full terminal transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dedicated VM for better separation.
 ## Features
 
 - **Persistent chat history** – conversations are stored in `chat.db` per user and session so they can be resumed later.
-- **Tool execution** – a built-in `execute_terminal` tool runs commands inside a Podman-based VM using `podman exec -i`. Network access is enabled and both stdout and stderr are captured (up to 10,000 characters). The VM is reused across chats when `PERSIST_VMS=1` so installed packages remain available.
+- **Tool execution** – a built-in `execute_terminal` tool runs commands inside a Podman-based VM using `podman exec -i`. Network access is enabled and a full terminal transcript (including prompts and command output) is captured up to 10,000 characters. The VM is reused across chats when `PERSIST_VMS=1` so installed packages remain available.
 - **System prompts** – every request includes a system prompt that guides the assistant to plan tool usage, verify results and avoid unnecessary jargon.
 
 ## Recommended Models


### PR DESCRIPTION
## Summary
- capture full transcript when falling back to host execution
- mention transcript capture in documentation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python - <<'PY'
from agent.tools import execute_terminal
print(execute_terminal('ls'))
print(execute_terminal('pwd'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684dd15c6d7883219c16d14a2545bfdf