### PR TITLE
Add interactive terminal session support

### DIFF
--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -29,7 +29,7 @@ from ..utils.logging import get_logger
 from .schema import Msg, ChatEvent
 from contextlib import suppress
 
-from ..tools import execute_terminal, set_vm
+from ..tools import execute_terminal, set_vm, close_terminal_session
 from ..vm import VMRegistry, is_vm_available
 
 from .state import SessionState, get_state
@@ -124,6 +124,7 @@ class ChatSession:
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         set_vm(None)
+        close_terminal_session()
         if self._vm:
             VMRegistry.release(self._user.username)
         if not _db.is_closed():

--- a/agent/tools/terminal_session.py
+++ b/agent/tools/terminal_session.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Optional
+import os
+import platform
+import io
+import threading
+import pexpect
+
+from ..utils.helpers import limit_chars
+from ..vm import LinuxVM, VM_CMD
+
+
+class TerminalSession:
+    """Manage an interactive shell either locally or inside a VM."""
+
+    def __init__(self, vm: Optional[LinuxVM] = None) -> None:
+        self._vm = vm
+        self._lock = threading.Lock()
+        self._child, self._prompt = self._spawn_shell()
+
+    # ------------------------------------------------------------------
+    def _spawn_shell(self) -> tuple[pexpect.spawn, str | pexpect.re]:
+        if self._vm:
+            if not self._vm._running:  # type: ignore[attr-defined]
+                raise RuntimeError("VM is not running")
+            prompt_env = self._vm._prompt_env or ""  # type: ignore[attr-defined]
+            prompt_re = self._vm._prompt_re or ""  # type: ignore[attr-defined]
+            child = pexpect.spawn(
+                VM_CMD,
+                [
+                    "exec",
+                    "-i",
+                    "-t",
+                    self._vm._name,  # type: ignore[attr-defined]
+                    "bash",
+                    "--noprofile",
+                    "--norc",
+                    "-i",
+                ],
+                env={"PS1": prompt_env},
+                encoding="utf-8",
+                echo=True,
+            )
+            child.expect(prompt_re)
+            return child, prompt_re
+        user = os.environ.get("USER", "user")
+        host = platform.node().split(".")[0]
+        cwd = os.path.basename(os.getcwd())
+        prompt = f"{user}@{host} {cwd} % "
+        child = pexpect.spawn(
+            "bash",
+            ["--noprofile", "--norc", "-i"],
+            env={"PS1": prompt},
+            encoding="utf-8",
+            echo=True,
+        )
+        child.expect_exact(prompt)
+        return child, prompt
+
+    # ------------------------------------------------------------------
+    def execute(self, command: str, *, stdin_data: str | bytes | None = None, timeout: int | None = 2) -> str:
+        """Send ``command`` or ``stdin_data`` to the shell and return output."""
+        with self._lock:
+            log = io.StringIO()
+            self._child.logfile_read = log
+
+            if command:
+                self._child.sendline(command)
+            if stdin_data is not None:
+                if isinstance(stdin_data, bytes):
+                    stdin_data = stdin_data.decode()
+                self._child.send(stdin_data)
+            try:
+                if isinstance(self._prompt, str):
+                    self._child.expect_exact(self._prompt, timeout=timeout)
+                else:
+                    self._child.expect(self._prompt, timeout=timeout)
+            except pexpect.TIMEOUT:
+                pass
+            return limit_chars(log.getvalue())
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        with self._lock:
+            if self._child.isalive():
+                self._child.close(force=True)

--- a/agent/vm/__init__.py
+++ b/agent/vm/__init__.py
@@ -235,6 +235,35 @@ class ContainerVM:
         )
         return await loop.run_in_executor(None, func)
 
+    # ------------------------------------------------------------------
+    def open_shell(self) -> tuple[pexpect.spawn, str]:
+        """Return a spawned interactive shell and prompt regex."""
+
+        if not self._running:
+            raise RuntimeError("VM is not running")
+
+        prompt_env = self._prompt_env or ""
+        prompt_re = self._prompt_re or ""
+
+        child = pexpect.spawn(
+            VM_CMD,
+            [
+                "exec",
+                "-i",
+                "-t",
+                self._name,
+                "bash",
+                "--noprofile",
+                "--norc",
+                "-i",
+            ],
+            env={"PS1": prompt_env},
+            encoding="utf-8",
+            echo=True,
+        )
+        child.expect(prompt_re)
+        return child, prompt_re
+
     def stop(self) -> None:
         """Terminate the VM if running."""
         if not self._running:


### PR DESCRIPTION
## Summary
- support interactive terminal sessions to handle prompts like `sudo`
- reset terminal session when VM changes
- expose `close_terminal_session` and shut down on chat exit

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dd38922988321a08b35cb30bc960c