### PR TITLE
Fix debug circular import

### DIFF
--- a/agent/chat/state.py
+++ b/agent/chat/state.py
@@ -27,6 +27,6 @@ def get_state(conv_id: int) -> SessionState:
     return state
 
 
-from .debug import debug_all
+from ..utils.debug import debug_all
 debug_all(globals())
 

--- a/agent/utils/debug.py
+++ b/agent/utils/debug.py
@@ -3,12 +3,12 @@ import inspect
 from functools import wraps
 from typing import Any, Callable
 
-from .logging import get_logger
+import logging
 
 
 def debug(func: Callable) -> Callable:
     """Decorator to log function entry and exit at DEBUG level."""
-    logger = get_logger(func.__module__)
+    logger = logging.getLogger(func.__module__)
 
     if asyncio.iscoroutinefunction(func):
         @wraps(func)
@@ -38,6 +38,6 @@ def debug_all(globals_dict: dict[str, Any]) -> None:
         elif inspect.isclass(obj):
             for attr_name, attr in list(vars(obj).items()):
                 if inspect.isfunction(attr) or inspect.ismethoddescriptor(attr):
-                    if attr_name.startswith("__"):
+                    if attr_name.startswith("__") or not hasattr(attr, "__module__"):
                         continue
                     setattr(obj, attr_name, debug(attr))

--- a/agent/utils/logging.py
+++ b/agent/utils/logging.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from __future__ import annotations
 
 from .debug import debug
 import logging


### PR DESCRIPTION
## Summary
- break circular import between utils.debug and utils.logging
- avoid wrapping descriptors without module info
- clean up import duplication
- fix wrong debug import in chat state

## Testing
- `pip install -r requirements.txt`
- `python -m bot` *(fails: DISCORD_TOKEN environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_684e27cd84c08321a12a203350bd11a0