### PR TITLE
Refactor DB operations into manager

### DIFF
--- a/agent/chat/messages.py
+++ b/agent/chat/messages.py
@@ -6,7 +6,7 @@ from typing import List
 from ollama import Message
 
 from .schema import Msg
-from ..db import Conversation, Message as DBMessage
+from ..db import Conversation, db
 
 __all__ = [
     "serialize_tool_calls",
@@ -45,10 +45,10 @@ def store_assistant_message(conversation: Conversation, message: Message) -> Non
     if message.tool_calls:
         data["tool_calls"] = [c.model_dump() for c in message.tool_calls]
 
-    DBMessage.create(
-        conversation=conversation,
-        role="assistant",
-        content=json.dumps(data),
+    db.create_message(
+        conversation,
+        "assistant",
+        json.dumps(data),
     )
 
 

--- a/agent/db/__init__.py
+++ b/agent/db/__init__.py
@@ -56,12 +56,105 @@ class Document(BaseModel):
     created_at = DateTimeField(default=datetime.utcnow)
 
 
+class DatabaseManager:
+    """Wrapper class to perform all DB operations."""
+
+    def __init__(self, database: SqliteDatabase) -> None:
+        self._db = database
+
+    def init_db(self) -> None:
+        if self._db.is_closed():
+            self._db.connect()
+        self._db.create_tables([User, Conversation, Message, Document])
+
+    def close(self) -> None:
+        if not self._db.is_closed():
+            self._db.close()
+
+    # ------------------------------------------------------------------
+    def get_or_create_user(self, username: str) -> User:
+        self.init_db()
+        user, _ = User.get_or_create(username=username)
+        return user
+
+    def get_or_create_conversation(self, user: User, session_name: str) -> Conversation:
+        self.init_db()
+        conv, _ = Conversation.get_or_create(user=user, session_name=session_name)
+        return conv
+
+    def create_message(self, conversation: Conversation, role: str, content: str) -> Message:
+        self.init_db()
+        return Message.create(conversation=conversation, role=role, content=content)
+
+    def list_messages(self, conversation: Conversation) -> list[Message]:
+        self.init_db()
+        return list(
+            Message.select()
+            .where(Message.conversation == conversation)
+            .order_by(Message.created_at)
+        )
+
+    def add_document(self, username: str, file_path: str, original_name: str) -> Document:
+        self.init_db()
+        user = self.get_or_create_user(username)
+        return Document.create(user=user, file_path=file_path, original_name=original_name)
+
+    def reset_history(self, username: str, session_name: str) -> int:
+        self.init_db()
+        try:
+            user = User.get(User.username == username)
+            conv = Conversation.get(
+                Conversation.user == user,
+                Conversation.session_name == session_name,
+            )
+        except (User.DoesNotExist, Conversation.DoesNotExist):
+            return 0
+
+        deleted = Message.delete().where(Message.conversation == conv).execute()
+        conv.delete_instance()
+        if not Conversation.select().where(Conversation.user == user).exists():
+            user.delete_instance()
+        return deleted
+
+    def list_sessions(self, username: str) -> list[str]:
+        self.init_db()
+        try:
+            user = User.get(User.username == username)
+        except User.DoesNotExist:
+            return []
+        return [c.session_name for c in Conversation.select().where(Conversation.user == user)]
+
+    def list_sessions_info(self, username: str) -> list[dict[str, str]]:
+        self.init_db()
+        try:
+            user = User.get(User.username == username)
+        except User.DoesNotExist:
+            return []
+
+        sessions = []
+        for conv in Conversation.select().where(Conversation.user == user):
+            last_msg = (
+                Message.select()
+                .where(Message.conversation == conv)
+                .order_by(Message.created_at.desc())
+                .first()
+            )
+            snippet = (last_msg.content[:50] + "…") if last_msg else ""
+            sessions.append({"name": conv.session_name, "last_message": snippet})
+        return sessions
+
+
+db = DatabaseManager(_db)
+
+
+
 __all__ = [
     "_db",
     "User",
     "Conversation",
     "Message",
     "Document",
+    "db",
     "reset_history",
     "list_sessions",
     "list_sessions_info",
@@ -71,70 +164,31 @@ __all__ = [
 
 def init_db() -> None:
     """Initialise the database and create tables if they do not exist."""
-    if _db.is_closed():
-        _db.connect()
-    _db.create_tables([User, Conversation, Message, Document])
+    db.init_db()
 
 
 def reset_history(username: str, session_name: str) -> int:
     """Delete all messages for the given user and session."""
 
-    init_db()
-    try:
-        user = User.get(User.username == username)
-        conv = Conversation.get(
-            Conversation.user == user, Conversation.session_name == session_name
-        )
-    except (User.DoesNotExist, Conversation.DoesNotExist):
-        return 0
-
-    deleted = Message.delete().where(Message.conversation == conv).execute()
-    conv.delete_instance()
-    if not Conversation.select().where(Conversation.user == user).exists():
-        user.delete_instance()
-    return deleted
+    return db.reset_history(username, session_name)
 
 
 def add_document(username: str, file_path: str, original_name: str) -> Document:
     """Record an uploaded document and return the created entry."""
 
-    init_db()
-    user, _ = User.get_or_create(username=username)
-    doc = Document.create(user=user, file_path=file_path, original_name=original_name)
-    return doc
+    return db.add_document(username, file_path, original_name)
 
 
 def list_sessions(username: str) -> list[str]:
     """Return all session names for the given ``username``."""
 
-    init_db()
-    try:
-        user = User.get(User.username == username)
-    except User.DoesNotExist:
-        return []
-    return [c.session_name for c in Conversation.select().where(Conversation.user == user)]
+    return db.list_sessions(username)
 
 
 def list_sessions_info(username: str) -> list[dict[str, str]]:
     """Return session names and a snippet of the last message for ``username``."""
 
-    init_db()
-    try:
-        user = User.get(User.username == username)
-    except User.DoesNotExist:
-        return []
-
-    sessions = []
-    for conv in Conversation.select().where(Conversation.user == user):
-        last_msg = (
-            Message.select()
-            .where(Message.conversation == conv)
-            .order_by(Message.created_at.desc())
-            .first()
-        )
-        snippet = (last_msg.content[:50] + "…") if last_msg else ""
-        sessions.append({"name": conv.session_name, "last_message": snippet})
-    return sessions
+    return db.list_sessions_info(username)
 
 from ..utils.debug import debug_all
 debug_all(globals())


### PR DESCRIPTION
## Summary
- encapsulate DB interactions with a new `DatabaseManager`
- use the manager throughout chat and session code
- simplify functions for adding messages and documents

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684eec52ca408321aed71a88469f8f81