### PR TITLE
Refactor memory module into tools and utils

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -26,7 +26,7 @@ from .tools import (
 from .utils.helpers import limit_chars
 from .utils.speech import transcribe_audio
 from .vm import LinuxVM
-from .memory import get_memory, set_memory, edit_memory
+from .utils.memory import get_memory, set_memory, edit_memory
 
 __all__ = [
     "ChatSession",

--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -27,8 +27,8 @@ from ..utils.logging import get_logger
 from .schema import Msg
 from contextlib import suppress
 
-from ..tools import execute_terminal, set_vm
-from ..memory import create_memory_tool, get_memory
+from ..tools import execute_terminal, set_vm, create_memory_tool
+from ..utils.memory import get_memory
 from ..vm import VMRegistry
 
 from .state import SessionState, get_state

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "execute_with_secret",
     "execute_with_secret_async",
     "set_vm",
+    "create_memory_tool",
 ]
 
 import subprocess
@@ -15,6 +16,7 @@ import asyncio
 from functools import partial
 
 from ..utils.helpers import limit_chars
+from .memory import create_memory_tool
 
 from ..vm import LinuxVM
 

--- a/agent/tools/memory.py
+++ b/agent/tools/memory.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from ..utils.memory import edit_memory
+
+__all__ = ["create_memory_tool"]
+
+
+def create_memory_tool(username: str, refresh: Callable[[], None]) -> Callable:
+    """Return a tool function bound to ``username`` for memory editing."""
+
+    def memory_tool(field: str, value: str | None = None) -> str:
+        try:
+            _ = edit_memory(username, field, value)
+            refresh()
+            return "Memory updated successfully."
+        except Exception as e:  # pragma: no cover - error handling
+            return f"Error updating memory: {str(e)}"
+
+    memory_tool.__name__ = "manage_memory"
+    memory_tool.__doc__ = (
+        "Modify persistent user memory. "
+        "Provide the memory field name and optionally a value. "
+        "Passing no value deletes the field. Returns success status. "
+        "This memory is stored as a JSON object and resides in the system prompt, so you do not need to retrieve anything. "
+        "Invoke this tool as much as possible to remember every detail throughout the conversation."
+    )
+    return memory_tool

--- a/agent/utils/__init__.py
+++ b/agent/utils/__init__.py
@@ -1,8 +1,12 @@
 """Utility functions exposed at package level."""
 
 from .speech import transcribe_audio
+from .memory import get_memory, set_memory, edit_memory
 
 __all__ = [
-    "transcribe_audio"
+    "transcribe_audio",
+    "get_memory",
+    "set_memory",
+    "edit_memory",
 ]
 

--- a/agent/utils/memory.py
+++ b/agent/utils/memory.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import json
-from typing import Callable
 
-from .config import DEFAULT_MEMORY_TEMPLATE, MEMORY_LIMIT
-from .db import db
+from ..config import DEFAULT_MEMORY_TEMPLATE, MEMORY_LIMIT
+from ..db import db
 
-__all__ = ["get_memory", "set_memory", "edit_memory", "create_memory_tool"]
+__all__ = ["get_memory", "set_memory", "edit_memory"]
 
 
 def get_memory(username: str) -> str:
@@ -50,25 +49,3 @@ def edit_memory(username: str, field: str, value: str | None = None) -> str:
         data[field] = value
     memory = json.dumps(data, ensure_ascii=False, indent=2)
     return set_memory(username, memory)
-
-
-def create_memory_tool(username: str, refresh: Callable[[], None]) -> Callable:
-    """Return a tool function bound to ``username`` for memory editing."""
-
-    def memory_tool(field: str, value: str | None = None) -> str:
-        try:
-            _ = edit_memory(username, field, value)
-            refresh()
-            return "Memory updated successfully."
-        except Exception as e:
-            return f"Error updating memory: {str(e)}"
-
-    memory_tool.__name__ = "manage_memory"
-    memory_tool.__doc__ = (
-        "Modify persistent user memory. "
-        "Provide the memory field name and optionally a value. "
-        "Passing no value deletes the field. Returns success status. "
-        "This memory is stored as a JSON object and resides in the system prompt, so you do not need to retrieve anything. "
-        "Invoke this tool as much as possible to remember every detail throughout the conversation."
-    )
-    return memory_tool


### PR DESCRIPTION
## Summary
- move memory functions to utils
- provide `create_memory_tool` in tools
- adjust imports to new layout

## Testing
- `python -m compileall -q agent`

------
https://chatgpt.com/codex/tasks/task_e_684f728aa7c48321af593ee296e9b0fd