### PR TITLE
Allow passing extra prompt fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,16 @@ Convenience helpers allow chatting without managing sessions directly:
 import asyncio
 import agent
 
-response = asyncio.run(agent.solo_chat("Hello"))
+# Extra fields can be appended to each prompt
+response = asyncio.run(
+    agent.solo_chat("Hello", extra={"time": "2025-06-01T10:00"})
+)
 print(response)
 ```
 
 Use `agent.team_chat` the same way to utilise the senior and junior agents.
+Both chat helpers accept an optional ``extra`` dictionary that is
+appended to the prompt as XML tags.
 
 ### Uploading Documents
 

--- a/agent/simple.py
+++ b/agent/simple.py
@@ -27,9 +27,10 @@ async def solo_chat(
     user: str = "default",
     session: str = "default",
     think: bool = True,
+    extra: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
     async with SoloChatSession(user=user, session=session, think=think) as chat:
-        async for part in chat.chat_stream(prompt):
+        async for part in chat.chat_stream(prompt, extra=extra):
             yield part
 
 
@@ -39,9 +40,10 @@ async def team_chat(
     user: str = "default",
     session: str = "default",
     think: bool = True,
+    extra: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
     async with TeamChatSession(user=user, session=session, think=think) as chat:
-        async for part in chat.chat_stream(prompt):
+        async for part in chat.chat_stream(prompt, extra=extra):
             yield part
 
 
@@ -99,7 +101,7 @@ async def write_file(path: str, content: str, *, user: str = "default") -> str:
     encoded = base64.b64encode(content.encode()).decode()
     cmd = (
         "python -c 'import base64,os; "
-        f"open({json.dumps(path)}, \"wb\").write(base64.b64decode({json.dumps(encoded)}))'"
+        f'open({json.dumps(path)}, "wb").write(base64.b64decode({json.dumps(encoded)}))\''
     )
     await vm_execute(cmd, user=user)
     return "Saved"
@@ -114,5 +116,7 @@ async def delete_path(path: str, *, user: str = "default") -> str:
     )
     return await vm_execute(cmd, user=user)
 
+
 from .utils.debug import debug_all
+
 debug_all(globals())


### PR DESCRIPTION
## Summary
- support `extra` fields for `solo_chat` and `team_chat`
- handle `extra` fields in `ChatSession` queueing and prompt formatting
- pass through `extra` in `TeamChatSession.chat_stream`
- document the new optional argument in README

## Testing
- `pip install -r requirements.txt`
- `python run.py` *(fails: FileNotFoundError: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68502ee11dc883219903b68c2ff5beb2