### PR TITLE
Add shutdown command for Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Run shell commands manually with `!exec <command>`. For example:
 !exec ls /data
 ```
 
+Administrators can shut down the bot with `!shutdown`.
+
 ## VM Configuration
 
 The shell commands run inside a Docker container. By default the image defined by `VM_IMAGE` is used (falling back to `python:3.11-slim`). When `PERSIST_VMS=1` (default) each user keeps the same container across sessions. Set `VM_STATE_DIR` to choose where per-user data is stored on the host.

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -103,6 +103,26 @@ class DiscordTeamBot(commands.Bot):
                 output = output[:1900] + "..."
             await ctx.reply(f"```\n{output}\n```", mention_author=False)
 
+        @self.command(name="shutdown")
+        @commands.has_permissions(administrator=True)
+        async def shutdown_cmd(ctx: commands.Context) -> None:
+            """Shut down the bot. Only administrators can invoke this."""
+
+            await ctx.reply("Shutting down...", mention_author=False)
+            await ctx.bot.close()
+
+        @shutdown_cmd.error
+        async def shutdown_cmd_error(
+            ctx: commands.Context, exc: commands.CommandError
+        ) -> None:
+            if isinstance(exc, commands.MissingPermissions):
+                await ctx.reply(
+                    "You do not have permission to shut down the bot.",
+                    mention_author=False,
+                )
+            else:  # pragma: no cover - runtime errors
+                await ctx.reply(f"Error: {exc}", mention_author=False)
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow administrators to terminate the Discord bot using `!shutdown`
- document the shutdown command in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6850395734a08321b502ff09fa97d512