### PR TITLE
Add dynamic mini-agent delegation

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,10 +1,5 @@
 from .chat import ChatSession
-from .sessions.team import (
-    TeamChatSession,
-    send_to_junior,
-    send_to_junior_async,
-    set_team,
-)
+from .sessions.team import TeamChatSession, set_team
 from .sessions.solo import SoloChatSession
 from .simple import (
     solo_chat,
@@ -34,8 +29,6 @@ __all__ = [
     "TeamChatSession",
     "execute_terminal",
     "execute_terminal_async",
-    "send_to_junior",
-    "send_to_junior_async",
     "set_team",
     "set_vm",
     "execute_with_secret",

--- a/agent/chat/messages.py
+++ b/agent/chat/messages.py
@@ -13,6 +13,7 @@ __all__ = [
     "format_output",
     "remove_tool_placeholder",
     "store_assistant_message",
+    "store_tool_message",
 ]
 
 
@@ -50,6 +51,13 @@ def store_assistant_message(conversation: Conversation, message: Message) -> Non
         "assistant",
         json.dumps(data),
     )
+
+
+def store_tool_message(conversation: Conversation, name: str, content: str) -> None:
+    """Persist tool messages with structured data."""
+
+    data = {"name": name, "content": content}
+    db.create_message(conversation, "tool", json.dumps(data))
 
 
 from ..utils.debug import debug_all

--- a/agent/config/__init__.py
+++ b/agent/config/__init__.py
@@ -24,10 +24,10 @@ LOG_LEVEL: Final[str] = os.getenv("LOG_LEVEL", "INFO").upper()
 TOOL_PLACEHOLDER_CONTENT: Final[str] = "Awaiting tool response..."
 
 SYSTEM_PROMPT: Final[str] = """
-You are **Starlette**, a human-like expert assistant who can help with anything. You work like any other intelligent assistant—but behind the scenes, you silently and expertly use a Linux system to complete all tasks.
-
-▸ You lead a quiet teammate named Starlette Jr., who helps you run all tasks. You must route *everything*, even tiny jobs, through **send_to_junior**.
-▸ The junior never speaks to the user. All replies from the junior arrive as tool outputs named `junior`. Messages are queued so neither agent interrupts the other.
+You are **Starlette**, a human-like expert assistant who can silently use a Linux system.
+You may spawn helper agents on demand with `spawn_agent` and talk to them via `send_to_agent`.
+These mini agents never speak to the user; their replies return as tool outputs named after them.
+Use them for planning, research, or parallel work and discard them once finished.
 
 General behavior:
 1. **Act like a natural, friendly, intelligent human assistant.** Never talk about Linux, terminals, or your tools unless the user specifically asks.
@@ -80,7 +80,17 @@ You are **Starlette Jr.**, assisting the senior agent (Starlette) only. You neve
 Your sole audience is Starlette, not the user.
 """.strip()
 
+MINI_AGENT_PROMPT: Final[str] = """
+You are {name}, assisting the senior agent Starlette only. {details}
+▸ Never address the user directly.
+▸ Use `execute_terminal` for all tasks and verify your work.
+▸ Keep responses short and focused.
+Additional context:
+{context}
+""".strip()
+
 MEMORY_LIMIT: Final[int] = int(os.getenv("MEMORY_LIMIT", "8000"))
+MAX_MINI_AGENTS: Final[int] = int(os.getenv("MAX_MINI_AGENTS", "4"))
 
 DEFAULT_MEMORY_TEMPLATE: Final[str] = (
     "{\n"

--- a/run.py
+++ b/run.py
@@ -10,8 +10,20 @@ async def _main() -> None:
     # document = await agent.upload_document("test.py", user="test_user", session="test_session")
     # print("Document uploaded:", document)
     agent.edit_protected_memory("test_user", ".env", "TEST_VAR=12345")
-    async for resp in agent.solo_chat("what's in the protected memory of yours?", user="test_user", session="test_session", think=False, extra={"time": datetime.datetime.now()}): # or agent.team_chat()
-        print("\n>>>", resp)
+    async for resp in agent.solo_chat(
+        "what's in the protected memory of yours?",
+        user="test_user",
+        session="test_session",
+        think=False,
+        extra={"time": datetime.datetime.now()},
+    ):
+        print("\nSOLO >>", resp)
+
+    async with agent.TeamChatSession(user="test_user", session="team_session", think=False) as chat:
+        async for part in chat.chat_stream(
+            "Ask any helper agents to greet us if needed"
+        ):
+            print("\nTEAM >>", part)
         
     # or using speech:
     # async for resp in agent.solo_chat(agent.transcribe_audio("path/to/audio/file.wav"), user="test_user", session="test_session", think=False):


### PR DESCRIPTION
## Summary
- allow `ChatSession` to skip persistence for ephemeral agents
- redesign `TeamChatSession` to spawn async mini agents on demand
- expose `send_to_agent` and `spawn_agent` APIs
- update system prompts and config with mini-agent settings
- store tool messages as JSON alongside assistant messages
- document usage of new team chat in `run.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850f212ca3c83219ca01da4d2afdd85