### PR TITLE
Add memory editing method in ChatSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Memory fields can be modified from a chat using the `manage_memory` tool or prog
 ```python
 import agent
 agent.edit_protected_memory("demo", "api_key", "secret")
+
+# or modify memory directly on a session
+async with agent.SoloChatSession(user="demo") as chat:
+    chat.edit_memory("api_key", "secret", protected=True)
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary
- add `edit_memory` method to `ChatSession` for manual updates
- expose memory editing example in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685162aee43c83218496fd8df9dcd48c