### PR TITLE
Add Dockerfile for API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+__pycache__/
+*.py[cod]
+*.db
+uploads/
+vm_state/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+# Install system dependencies required by whisper
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port $PORT"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ Adjust these variables in your environment or `.env` file.
 
 Each user receives a dedicated Docker container. Files uploaded through the API are mounted at `/data` in the container and persist according to `VM_STATE_DIR`. Commands are executed with `execute_terminal` which streams output back to the model.
 
+## Docker Image
+
+The repository includes a `Dockerfile` for running the API on Google Cloud Run.
+Build and test the image locally with:
+
+```bash
+docker build -t llmos-agent-api .
+docker run -p 8080:8080 llmos-agent-api
+```
+
+Deploy the image to Cloud Run after pushing it to your registry:
+
+```bash
+gcloud run deploy llmos-agent-api \
+    --image gcr.io/PROJECT_ID/llmos-agent-api \
+    --region REGION --platform managed --allow-unauthenticated
+```
+
 ## License
 
 This project is licensed under the Apache 2.0 License. See [LICENSE](LICENSE) for details.

--- a/api/__main__.py
+++ b/api/__main__.py
@@ -1,11 +1,14 @@
-import uvicorn
+from __future__ import annotations
+
+import os
 import uvicorn
 
 from .main import app
 
 
 def main() -> None:
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    port = int(os.environ.get("PORT", "8080"))
+    uvicorn.run(app, host="0.0.0.0", port=port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- provide a Dockerfile and dockerignore for deploying the API
- adjust `api.__main__` to read the port from `$PORT`
- document Docker image usage in the README

## Testing
- `python -m api 2>&1 | head -n 5`
- `python -m pip install -r requirements.txt` *(fails: torch wheel download huge)*

------
https://chatgpt.com/codex/tasks/task_e_68521070371883218f5cec0f675345c5