### PR TITLE
Add endpoints to reset memory and delete chat history

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, UploadFile, File
 from pydantic import BaseModel
 
 import agent
-from agent.db import reset_history, list_sessions_info
+from agent.db import delete_history, reset_memory, list_sessions_info
 from agent.utils.logging import get_logger
 
 app = FastAPI(title="llmOS Agent API")
@@ -138,9 +138,15 @@ async def memory_get(user: str) -> dict[str, str]:
     return {"memory": agent.get_memory(user)}
 
 
-@app.post("/sessions/{user}/{session}/reset")
-async def session_reset(user: str, session: str) -> dict[str, int]:
-    deleted = reset_history(user, session)
+@app.post("/memory/{user}/reset")
+async def memory_reset_endpoint(user: str) -> dict[str, str]:
+    memory = reset_memory(user)
+    return {"memory": memory}
+
+
+@app.post("/sessions/{user}/{session}/delete")
+async def session_delete(user: str, session: str) -> dict[str, int]:
+    deleted = delete_history(user, session)
     return {"deleted": deleted}
 
 

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -15,7 +15,7 @@ from discord.ext import commands
 from dotenv import load_dotenv
 
 import agent
-from agent.db import reset_history
+from agent.db import delete_history
 from agent.utils.logging import get_logger
 from agent.utils.speech import transcribe_audio
 from agent.sessions.team import TeamChatSession
@@ -88,7 +88,7 @@ class DiscordTeamBot(commands.Bot):
     def _register_commands(self) -> None:
         @self.command(name="reset")
         async def reset(ctx: commands.Context) -> None:
-            deleted = reset_history(str(ctx.author.id), str(ctx.channel.id))
+            deleted = delete_history(str(ctx.author.id), str(ctx.channel.id))
             await ctx.reply(
                 f"Chat history cleared ({deleted} messages deleted).",
             )


### PR DESCRIPTION
## Summary
- extend `DatabaseManager` with `delete_history` and `reset_memory`
- expose new database functions and keep backward compat with `reset_history`
- update API to use new functions and add `/memory/{user}/reset` endpoint
- update Discord bot to use `delete_history`

## Testing
- `pip install -q -r requirements.txt` *(failed: no output)*
- `pytest -q`
- `python -m py_compile agent/db/__init__.py api/main.py bot/discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685219a0d64083219a5fa137e3e41f4a