### PR TITLE
Add authentication enforcement option

### DIFF
--- a/agent/config/__init__.py
+++ b/agent/config/__init__.py
@@ -21,6 +21,11 @@ VM_DOCKER_HOST: Final[str | None] = os.getenv("VM_DOCKER_HOST")
 DB_PATH: Final[str] = os.getenv("DB_PATH", str(Path.cwd() / "chat.db"))
 HARD_TIMEOUT: Final[int] = int(os.getenv("HARD_TIMEOUT", "5"))
 LOG_LEVEL: Final[str] = os.getenv("LOG_LEVEL", "INFO").upper()
+SECRET_KEY: Final[str] = os.getenv("SECRET_KEY", "CHANGE_ME")
+ACCESS_TOKEN_EXPIRE_MINUTES: Final[int] = int(
+    os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+)
+REQUIRE_AUTH: Final[bool] = os.getenv("REQUIRE_AUTH", "0") == "1"
 
 TOOL_PLACEHOLDER_CONTENT: Final[str] = "Awaiting tool response..."
 
@@ -131,6 +136,9 @@ class Config:
     db_path: str = DB_PATH
     hard_timeout: int = HARD_TIMEOUT
     log_level: str = LOG_LEVEL
+    secret_key: str = SECRET_KEY
+    access_token_expire_minutes: int = ACCESS_TOKEN_EXPIRE_MINUTES
+    require_auth: bool = REQUIRE_AUTH
     tool_placeholder_content: str = TOOL_PLACEHOLDER_CONTENT
     system_prompt: str = SYSTEM_PROMPT
     solo_system_prompt: str = SOLO_SYSTEM_PROMPT
@@ -159,6 +167,9 @@ __all__ = [
     "DB_PATH",
     "HARD_TIMEOUT",
     "LOG_LEVEL",
+    "SECRET_KEY",
+    "ACCESS_TOKEN_EXPIRE_MINUTES",
+    "REQUIRE_AUTH",
     "TOOL_PLACEHOLDER_CONTENT",
     "SYSTEM_PROMPT",
     "SOLO_SYSTEM_PROMPT",

--- a/agent/db/__init__.py
+++ b/agent/db/__init__.py
@@ -42,6 +42,7 @@ class BaseModel(Model):
 class User(BaseModel):
     id = AutoField()
     username = CharField(unique=True)
+    password_hash = CharField()
     memory = TextField(default="")
 
 
@@ -91,6 +92,17 @@ class DatabaseManager:
         self.init_db()
         user, _ = User.get_or_create(username=username)
         return user
+
+    def register_user(self, username: str, password_hash: str) -> User:
+        self.init_db()
+        return User.create(username=username, password_hash=password_hash)
+
+    def authenticate_user(self, username: str) -> User | None:
+        self.init_db()
+        try:
+            return User.get(User.username == username)
+        except User.DoesNotExist:
+            return None
 
     def get_or_create_conversation(self, user: User, session_name: str) -> Conversation:
         self.init_db()
@@ -207,6 +219,8 @@ __all__ = [
     "add_document",
     "get_memory",
     "set_memory",
+    "register_user",
+    "authenticate_user",
 ]
 
 
@@ -249,6 +263,18 @@ def set_memory(username: str, memory: str) -> str:
     """Persist ``memory`` for ``username``."""
 
     return db.set_memory(username, memory)
+
+
+def register_user(username: str, password_hash: str) -> User:
+    """Create a new user with ``password_hash``."""
+
+    return db.register_user(username, password_hash)
+
+
+def authenticate_user(username: str) -> User | None:
+    """Return user record if ``username`` exists."""
+
+    return db.authenticate_user(username)
 
 
 def list_sessions(username: str) -> list[str]:

--- a/api/main.py
+++ b/api/main.py
@@ -3,15 +3,78 @@ from __future__ import annotations
 import os
 import tempfile
 
-from fastapi import FastAPI, UploadFile, File
+from datetime import datetime, timedelta
+from fastapi import FastAPI, UploadFile, File, HTTPException, status, Depends
+from fastapi.security import (
+    OAuth2PasswordRequestForm,
+    HTTPAuthorizationCredentials,
+    HTTPBearer,
+)
 from pydantic import BaseModel
+from passlib.context import CryptContext
+from jose import jwt, JWTError
+from agent.config import DEFAULT_CONFIG
+from agent.db import (
+    delete_history,
+    reset_memory,
+    list_sessions_info,
+    register_user,
+    authenticate_user,
+)
 
 import agent
-from agent.db import delete_history, reset_memory, list_sessions_info
 from agent.utils.logging import get_logger
 
 app = FastAPI(title="llmOS Agent API")
 LOG = get_logger(__name__)
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+security = HTTPBearer(auto_error=False)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    cfg = DEFAULT_CONFIG
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=cfg.access_token_expire_minutes)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, cfg.secret_key, algorithm="HS256")
+
+
+def get_current_username(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> str | None:
+    token = credentials.credentials if credentials else None
+    cfg = DEFAULT_CONFIG
+    if not token:
+        if cfg.require_auth:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+        return None
+    try:
+        payload = jwt.decode(token, cfg.secret_key, algorithms=["HS256"])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise JWTError
+        return username
+    except JWTError:
+        if cfg.require_auth:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        return None
+
+
+def _use_user(request_user: str, token_user: str | None) -> str:
+    """Return ``token_user`` if set, otherwise ``request_user``."""
+
+    return token_user or request_user
 
 
 @app.get("/health")
@@ -26,6 +89,16 @@ class ChatRequest(BaseModel):
     session: str = "default"
     think: bool = True
     extra: dict[str, str] | None = None
+
+
+class RegisterRequest(BaseModel):
+    username: str
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
 
 
 async def _chat(method, req: ChatRequest) -> str:
@@ -43,15 +116,40 @@ async def _chat(method, req: ChatRequest) -> str:
 
 
 @app.post("/chat/solo")
-async def chat_solo(req: ChatRequest) -> dict[str, str]:
+async def chat_solo(
+    req: ChatRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    req.user = _use_user(req.user, token_user)
     text = await _chat(agent.solo_chat, req)
     return {"response": text}
 
 
 @app.post("/chat/team")
-async def chat_team(req: ChatRequest) -> dict[str, str]:
+async def chat_team(
+    req: ChatRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    req.user = _use_user(req.user, token_user)
     text = await _chat(agent.team_chat, req)
     return {"response": text}
+
+
+@app.post("/auth/register", status_code=201)
+async def register(req: RegisterRequest) -> TokenResponse:
+    hashed = get_password_hash(req.password)
+    user = register_user(req.username, hashed)
+    token = create_access_token({"sub": user.username})
+    return TokenResponse(access_token=token)
+
+
+@app.post("/auth/login")
+async def login(form: OAuth2PasswordRequestForm = Depends()) -> TokenResponse:
+    user = authenticate_user(form.username)
+    if not user or not verify_password(form.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = create_access_token({"sub": user.username})
+    return TokenResponse(access_token=token)
 
 
 class CommandRequest(BaseModel):
@@ -61,7 +159,11 @@ class CommandRequest(BaseModel):
 
 
 @app.post("/vm/execute")
-async def vm_execute(req: CommandRequest) -> dict[str, str]:
+async def vm_execute(
+    req: CommandRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    req.user = _use_user(req.user, token_user)
     output = await agent.vm_execute(req.command, user=req.user, timeout=req.timeout)
     return {"output": output}
 
@@ -72,13 +174,21 @@ class PathRequest(BaseModel):
 
 
 @app.get("/vm/list")
-async def list_directory(req: PathRequest) -> list[dict[str, str]]:
+async def list_directory(
+    req: PathRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> list[dict[str, str]]:
+    req.user = _use_user(req.user, token_user)
     rows = await agent.list_dir(req.path, user=req.user)
     return [{"name": name, "is_dir": is_dir} for name, is_dir in rows]
 
 
 @app.get("/vm/read")
-async def read_file(req: PathRequest) -> dict[str, str]:
+async def read_file(
+    req: PathRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    req.user = _use_user(req.user, token_user)
     content = await agent.read_file(req.path, user=req.user)
     return {"content": content}
 
@@ -88,13 +198,21 @@ class WriteRequest(PathRequest):
 
 
 @app.post("/vm/write")
-async def write_file(req: WriteRequest) -> dict[str, str]:
+async def write_file(
+    req: WriteRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    req.user = _use_user(req.user, token_user)
     result = await agent.write_file(req.path, req.content, user=req.user)
     return {"result": result}
 
 
 @app.delete("/vm/delete")
-async def delete(req: PathRequest) -> dict[str, str]:
+async def delete(
+    req: PathRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    req.user = _use_user(req.user, token_user)
     result = await agent.delete_path(req.path, user=req.user)
     return {"result": result}
 
@@ -108,7 +226,13 @@ async def _save_temp(file: UploadFile) -> str:
 
 
 @app.post("/upload")
-async def upload(file: UploadFile = File(...), user: str = "default", session: str = "default") -> dict[str, str]:
+async def upload(
+    file: UploadFile = File(...),
+    user: str = "default",
+    session: str = "default",
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    user = _use_user(user, token_user)
     path = await _save_temp(file)
     try:
         vm_path = await agent.upload_document(path, user=user, session=session)
@@ -125,7 +249,11 @@ class MemoryEditRequest(BaseModel):
 
 
 @app.post("/memory/edit")
-async def memory_edit(req: MemoryEditRequest) -> dict[str, str]:
+async def memory_edit(
+    req: MemoryEditRequest,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    req.user = _use_user(req.user, token_user)
     if req.protected:
         mem = agent.edit_protected_memory(req.user, req.field, req.value)
     else:
@@ -134,24 +262,41 @@ async def memory_edit(req: MemoryEditRequest) -> dict[str, str]:
 
 
 @app.get("/memory/{user}")
-async def memory_get(user: str) -> dict[str, str]:
+async def memory_get(
+    user: str,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    user = _use_user(user, token_user)
     return {"memory": agent.get_memory(user)}
 
 
 @app.post("/memory/{user}/reset")
-async def memory_reset_endpoint(user: str) -> dict[str, str]:
+async def memory_reset_endpoint(
+    user: str,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, str]:
+    user = _use_user(user, token_user)
     memory = reset_memory(user)
     return {"memory": memory}
 
 
 @app.post("/sessions/{user}/{session}/delete")
-async def session_delete(user: str, session: str) -> dict[str, int]:
+async def session_delete(
+    user: str,
+    session: str,
+    token_user: str | None = Depends(get_current_username),
+) -> dict[str, int]:
+    user = _use_user(user, token_user)
     deleted = delete_history(user, session)
     return {"deleted": deleted}
 
 
 @app.get("/sessions/{user}")
-async def sessions(user: str) -> list[dict[str, str]]:
+async def sessions(
+    user: str,
+    token_user: str | None = Depends(get_current_username),
+) -> list[dict[str, str]]:
+    user = _use_user(user, token_user)
     return list_sessions_info(user)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ openai-whisper
 fastapi
 uvicorn[standard]
 python-multipart
+passlib[bcrypt]
+python-jose[cryptography]


### PR DESCRIPTION
## Summary
- introduce `REQUIRE_AUTH` config flag
- implement token validation helper and user override logic
- gate API endpoints behind optional authentication
- keep dependencies for password hashing and JWT

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install passlib[bcrypt] python-jose[cryptography]`


------
https://chatgpt.com/codex/tasks/task_e_68521bf5f2dc83219bbe1c67af8cc095