### PR TITLE
Add notification API and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ async with agent.SoloChatSession(user="demo") as chat:
     chat.edit_memory("api_key", "secret", protected=True)
 ```
 
+### Notifications
+
+Queue background notifications for an agent using ``send_notification`` or via
+an active session:
+
+```python
+import agent
+
+# Send a notification without opening a chat session
+agent.send_notification("Report ready", user="demo")
+
+async with agent.TeamChatSession(user="demo") as chat:
+    await chat.send_notification("Session starting")
+    async for part in chat.chat_stream("hello"):
+        print(part)
+```
+
 ## Configuration
 
 Behaviour can be tuned through environment variables:

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -10,6 +10,7 @@ from .simple import (
     write_file,
     delete_path,
     vm_execute,
+    send_notification,
 )
 from .tools import (
     execute_terminal,
@@ -44,6 +45,7 @@ __all__ = [
     "write_file",
     "delete_path",
     "vm_execute",
+    "send_notification",
     "transcribe_audio",
     "get_memory",
     "set_memory",

--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -212,6 +212,20 @@ class ChatSession:
         return memory
 
     # ------------------------------------------------------------------
+    async def send_notification(self, message: str) -> None:
+        """Queue a notification for this session's agent.
+
+        The notification will be delivered as a ``notification`` tool output
+        the next time the agent is idle.
+        """
+
+        if self._vm is None:
+            raise RuntimeError("Session is not active")
+
+        self._vm.post_notification(str(message))
+        await self._notification_queue.put(str(message))
+
+    # ------------------------------------------------------------------
     def _load_history(self) -> List[Msg]:
         messages: List[Msg] = []
         if not self._persist or not self._conversation:

--- a/agent/simple.py
+++ b/agent/simple.py
@@ -19,6 +19,7 @@ __all__ = [
     "write_file",
     "delete_path",
     "vm_execute",
+    "send_notification",
 ]
 
 
@@ -134,6 +135,16 @@ async def delete_path(path: str, *, user: str = "default") -> str:
         f"else echo File not found; fi'"
     )
     return await vm_execute(cmd, user=user)
+
+
+def send_notification(message: str, *, user: str = "default") -> None:
+    """Post ``message`` to ``user``'s notification queue."""
+
+    vm = VMRegistry.acquire(user)
+    try:
+        vm.post_notification(str(message))
+    finally:
+        VMRegistry.release(user)
 
 
 from .utils.debug import debug_all

--- a/run.py
+++ b/run.py
@@ -48,10 +48,15 @@ async def _main(username: str, session: str) -> None:
     # ensure_user(username, password)
 
     async with agent.TeamChatSession(user=username, session=session, think=False) as chat:
+        await chat.send_notification("Session started")
         async for part in chat.chat_stream(
             "solve cancer. do not come back until you have a solution.",
         ):
             print("\nTEAM >>", part)
+        await chat.send_notification("Session finished")
+
+    # This notification will be delivered the next time the user starts a session
+    agent.send_notification("Background job completed", user=username)
         
     # or using speech:
     # async for resp in agent.solo_chat(agent.transcribe_audio("path/to/audio/file.wav"), user="test_user", session="test_session", think=False):


### PR DESCRIPTION
## Summary
- implement notification helper on `ChatSession`
- add `send_notification` convenience function
- update demo script to showcase notifications
- document new feature in README

## Testing
- `python -m py_compile run.py agent/__init__.py agent/simple.py agent/chat/session.py`

------
https://chatgpt.com/codex/tasks/task_e_6852c65c34608321a5d4b555bac4c396